### PR TITLE
fix: #312 daemon(8) 配下で STDIO が無リーダー pipe を指す問題に対処

### DIFF
--- a/bin/puma_daemon.rb
+++ b/bin/puma_daemon.rb
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.unshift(File.join(File.expand_path('..', __dir__), 'app/lib'))
 
+$stdin.reopen(File::NULL, 'r') unless $stdin.tty?
+[$stdout, $stderr].each do |io|
+  io.reopen(File::NULL, 'w') unless io.tty?
+end
+
 require 'cure_api'
 module CureAPI
   if PumaDaemon.disable?


### PR DESCRIPTION
## Summary

- `bin/puma_daemon.rb` 冒頭で `$stdin/$stdout/$stderr` を非 tty 時に `/dev/null` へ無条件 reopen
- 2026-04-25 本番障害（cure-api.precure.ml 全リクエスト 500）の根本対処

## 経緯

詳細は #312 を参照。要約:

- daemon(8) 配下で Puma の fd 0/1/2 が無リーダー pipe を掴む
- Sinatra の `dump_errors!` (`STDERR.puts`) が `Errno::EPIPE` で死亡
- `handle_exception!` の rescue で EPIPE が再 raise され、**本来の例外が一切ログに残らない**

mulukhiya #4144（cure-api 独立化のきっかけ）から始まった一連の Broken pipe 事案の延長線上にあり、独立化したはずの cure-api 自身が同じ罠を踏んだ形。

## なぜ tomato-shrieker パターンか

mulukhiya 側 [app/initializer/puma.rb](https://github.com/pooza/mulukhiya-toot-proxy/blob/develop/app/initializer/puma.rb) の「flush 試行→例外時のみ reopen」は、tomato-shrieker #1442 で**空バッファの flush は EPIPE を出さず素通りする**と判明済み。cure-api では最初から無条件 reopen 版（tomato-shrieker v4.1.1 と同形）を採用する。

## Test plan

- [ ] develop マージ後、本番 lbock にデプロイ
- [ ] `procstat -f <pid>` で fd 0/1/2 が `/dev/null` (`v - r--w--`) を指していることを確認
- [ ] エンドポイント疎通: `curl http://localhost:3009/girls/cure_black` が 200
- [ ] 万一例外発生時に EPIPE ではなく本来の例外内容が（修正後 #302 解消で）syslog に出ること（後続課題）

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)