### PR TITLE
fix: #302 Environment.type で ENV['RACK_ENV'] を優先

### DIFF
--- a/app/lib/cure_api/environment.rb
+++ b/app/lib/cure_api/environment.rb
@@ -7,5 +7,11 @@ module CureAPI
     def self.dir
       return CureAPI.dir
     end
+
+    def self.type
+      env = ENV['RACK_ENV']
+      return env.to_sym if env && !env.empty?
+      return super
+    end
   end
 end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -6,7 +6,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/cure-api
-  version: 3.0.2
+  version: 3.0.3
 gas:
   girls:
     url: https://script.google.com/macros/s/AKfycbyz2apomjlyawkhLI-XvZveeEPVvLXmGzshHiE9mfsZT8DOOKAwKRQ_CxzfBiv7Qki33A/exec


### PR DESCRIPTION
## Summary

cure-api 側の局所 override で \`Environment.type\` に ENV['RACK_ENV'] を読ませる。v3.0.3 として小修正リリースする。

## 経緯

#302 の根本原因が判明:

- \`Ginseng::Environment.type\` は \`Config.instance['/environment']\` のみ読み、ENV を見ない
- cure-api の application.yaml に \`/environment\` キーは存在しない
- 結果、rc.d で \`RACK_ENV=production\` を渡しても \`rescue :development\` に落ち、Puma は development モードで起動
- セキュリティ的にも問題: development では Sinatra のエラー詳細が外部に出る（今日の EPIPE スタック露出もこれが効いていた）

## 修正

[app/lib/cure_api/environment.rb](https://github.com/pooza/cure-api/blob/fix/env-rack-env-fallback/app/lib/cure_api/environment.rb) で \`type\` を override:

\`\`\`ruby
def self.type
  env = ENV['RACK_ENV']
  return env.to_sym if env && !env.empty?
  return super
end
\`\`\`

優先順位: ENV['RACK_ENV'] → Config['/environment'] → :development

## ginseng-core 本体の対処

ginseng-core #479 で起票済み。横断的影響評価が必要なため別作業とする。本 PR は cure-api 局所対処にとどめる。

## Test plan

- [ ] develop マージ後 v3.0.3 として release
- [ ] 本番デプロイ後、新 Puma 起動ログが \`Environment: production\` になること
- [ ] \`procstat -e <pid>\` で RACK_ENV=production が反映されていること（既に v3.0.2 時点で確認済み）

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)