### PR TITLE
3.0.3

### DIFF
--- a/app/lib/cure_api/environment.rb
+++ b/app/lib/cure_api/environment.rb
@@ -7,5 +7,11 @@ module CureAPI
     def self.dir
       return CureAPI.dir
     end
+
+    def self.type
+      env = ENV['RACK_ENV']
+      return env.to_sym if env && !env.empty?
+      return super
+    end
   end
 end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -6,7 +6,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/cure-api
-  version: 3.0.2
+  version: 3.0.3
 gas:
   girls:
     url: https://script.google.com/macros/s/AKfycbyz2apomjlyawkhLI-XvZveeEPVvLXmGzshHiE9mfsZT8DOOKAwKRQ_CxzfBiv7Qki33A/exec


### PR DESCRIPTION
## Summary

v3.0.3 リリース。v3.0.2 リリース直後に判明した #302 の対処。

## 含まれる変更

- **fix: Environment.type で ENV['RACK_ENV'] を優先** (#302, #315)
  - cure-api の application.yaml に \`/environment\` キーが無いため、Puma が development モードで起動していた問題
  - ginseng-core 本体の修正は ginseng-core #479 で別途対応

## Test plan

- [ ] マージ後 v3.0.3 タグ作成・GitHub Release 公開
- [ ] 本番 lbock デプロイ
- [ ] Puma 起動ログが \`Environment: production\` になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)