### PR TITLE
3.1.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@
 - **技術スタック**: Ruby / Sinatra (ginseng-web) / Puma
 - **データソース**: Google Spreadsheet → GAS (Google Apps Script) → JSON API
 - **リポジトリ**: `pooza/cure-api`（旧名 `mulukhiya-rubicure`、GitHub リネーム済み）
-- **現バージョン**: 3.1.0
+- **現バージョン**: 3.1.1
 
 ## 経緯
 

--- a/app/lib/cure_api/puma_daemon.rb
+++ b/app/lib/cure_api/puma_daemon.rb
@@ -2,9 +2,20 @@ module CureAPI
   class PumaDaemon < Ginseng::Daemon
     include Package
 
+    # ⚠⚠ **`bundle exec` を通す。**素の `puma` を叩くと、**Ruby の default gem が先に
+    # activate されて lockfile と衝突する。**
+    #
+    # 実際に踏んだ（2026-08-13・dev25）: Ruby 4.0.6 の default gem は fileutils 1.8.0 だが、
+    # `ginseng-core` が `fileutils (~> 1.7.0)` を要求するため lockfile は 1.7.3。
+    # ⚠ `You have already activated fileutils 1.8.0, but your Gemfile requires 1.7.3`
+    # で起動しなくなった。
+    #
+    # ⚠ **Ruby のバージョンを下げて回避しない。**あの箱では `.ruby-version` を手で
+    # 4.0.5 に書き換えて凌いだ痕跡が残っていたが、**リポジトリに戻らないドリフトを
+    # 増やすだけ**で、default gem が動くたびに再発する。
     def command
       return Ginseng::CommandLine.new([
-        'puma',
+        'bundle', 'exec', 'puma',
         File.join(Environment.dir, 'config.ru'),
         '--port', config['/puma/port'].to_s,
         '--environment', Environment.type

--- a/bin/puma_daemon.rb
+++ b/bin/puma_daemon.rb
@@ -1,9 +1,19 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.unshift(File.join(File.expand_path('..', __dir__), 'app/lib'))
 
-$stdin.reopen(File::NULL, 'r') unless $stdin.tty?
-[$stdout, $stderr].each do |io|
-  io.reopen(File::NULL, 'w') unless io.tty?
+# ⚠⚠ **黙らせるのは常駐する経路だけ。**`start` / `restart` は常駐して標準出力の
+# 相手が居なくなるので `Errno::EPIPE` を避けるために落とすが、**`stop` / `status` の
+# 出力は監視やスクリプトから読めないと意味が無い。**
+#
+# ⚠ 無条件に落としていたため、**起動失敗のエラーが 1 文字も出ずに「何も起きない」
+# だけになっていた**（2026-08-13・dev25 で実際に原因の特定に時間を溶かした）。
+DAEMONIZING = ['start', 'restart'].include?(ARGV.first.to_s).freeze
+
+if DAEMONIZING
+  $stdin.reopen(File::NULL, 'r') unless $stdin.tty?
+  [$stdout, $stderr].each do |io|
+    io.reopen(File::NULL, 'w') unless io.tty?
+  end
 end
 
 require 'cure_api'

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -6,7 +6,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/cure-api
-  version: 3.1.0
+  version: 3.1.1
 gas:
   girls:
     url: https://script.google.com/macros/s/AKfycbyz2apomjlyawkhLI-XvZveeEPVvLXmGzshHiE9mfsZT8DOOKAwKRQ_CxzfBiv7Qki33A/exec


### PR DESCRIPTION
## ⚠⚠ 常駐が起動しない（3.1.0 のデプロイで発覚）

`PumaDaemon` が素の `puma` を叩いており、**Ruby の default gem が先に activate されて lockfile と衝突する。**

```
You have already activated fileutils 1.8.0, but your Gemfile requires fileutils 1.7.3.
```

`ginseng-core` が `fileutils (~> 1.7.0)` を要求するため lockfile は 1.7.3 だが、**Ruby 4.0.6 の default gem は 1.8.0**。`bundle exec` を通せば解決する（dev25 で確認済み）。

⚠ **Ruby を下げて回避しない。**dev25 には `.ruby-version` を手で 4.0.5 に書き換えて凌いだ痕跡が残っていた（`pooza/chubo2#82` の「ステージングで先に整えた設定を本番へフィードバックする」の実例）。リポジトリに戻らないドリフトを増やすだけで、default gem が動くたびに再発する。

## ⚠⚠ エラーが 1 文字も出ていなかった

`bin/puma_daemon.rb` が TTY でないとき出力を **無条件に** `/dev/null` へ落としていたため、**起動失敗が「何も起きない」だけ**になっていた（`status` すら黙る）。原因の特定に時間を溶かした。

黙らせるのは `start` / `restart`（常駐して標準出力の相手が居なくなる経路）だけにする。⚠ **`stop` / `status` の出力は監視やスクリプトから読めないと意味が無い。**

## 確認

`rubocop` 無指摘 / `rake test` 27 tests 0 failures。