### PR TITLE
3.1.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@
 - **技術スタック**: Ruby / Sinatra (ginseng-web) / Puma
 - **データソース**: Google Spreadsheet → GAS (Google Apps Script) → JSON API
 - **リポジトリ**: `pooza/cure-api`（旧名 `mulukhiya-rubicure`、GitHub リネーム済み）
-- **現バージョン**: 3.1.1
+- **現バージョン**: 3.1.2
 
 ## 経緯
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: e48aeea725f438aded0f272606ac4b98e232e753
+  revision: d1878f777ff508a9acb0be30e9a091e41b0c52ba
   branch: main
   specs:
-    ginseng-core (1.16.2)
+    ginseng-core (1.16.3)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -6,7 +6,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/cure-api
-  version: 3.1.1
+  version: 3.1.2
 gas:
   girls:
     url: https://script.google.com/macros/s/AKfycbyz2apomjlyawkhLI-XvZveeEPVvLXmGzshHiE9mfsZT8DOOKAwKRQ_CxzfBiv7Qki33A/exec


### PR DESCRIPTION
## ginseng-core 1.16.3 へ

`pooza/ginseng-core#507` を取り込む。⚠⚠ **`logger.rb` が `addressable` を require しておらず、常駐スクリプトから直接 require する経路で起動しなくなっていた**（3.1.0 / 3.1.1 のデプロイで発覚）。

```
lib/ginseng/logger.rb:29: uninitialized constant Ginseng::Logger::Addressable
```

⚠ **Sinatra 経由（`config.ru`）では他の gem が先に `addressable` を読むので通る。**常駐の経路だけで落ちるため、Web の疎通確認では検知できない。

## 確認

ローカルで実際に常駐させて疎通まで見た。

```
PumaDaemon is running (PID ...)
/girls/index    HTTP 200
/singers/index  HTTP 200
/nonexistent    HTTP 404
```

`rubocop` 無指摘 / `rake test` 27 tests 0 failures。