### PR TITLE
3.1.3

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@
 - **技術スタック**: Ruby / Sinatra (ginseng-web) / Puma
 - **データソース**: Google Spreadsheet → GAS (Google Apps Script) → JSON API
 - **リポジトリ**: `pooza/cure-api`（旧名 `mulukhiya-rubicure`、GitHub リネーム済み）
-- **現バージョン**: 3.1.2
+- **現バージョン**: 3.1.3
 
 ## 経緯
 
@@ -51,7 +51,7 @@
 |------|-----|
 | パス | `/home/mastodon/repos/cure-api` |
 | ポート | 3009 |
-| ドメイン | `cure-api.st.precure.ml` |
+| ドメイン | `cure-api.st2.precure.ml` |
 | SSH | `dev25.b-shock.local`（pooza ユーザーで入り、`mastodon` へ sudo） |
 
 ### 同居サービス

--- a/app/lib/cure_api/puma_daemon.rb
+++ b/app/lib/cure_api/puma_daemon.rb
@@ -13,11 +13,22 @@ module CureAPI
     # ⚠ **Ruby のバージョンを下げて回避しない。**あの箱では `.ruby-version` を手で
     # 4.0.5 に書き換えて凌いだ痕跡が残っていたが、**リポジトリに戻らないドリフトを
     # 増やすだけ**で、default gem が動くたびに再発する。
+    # ⚠⚠ **待受アドレスを明示する（`--port` に任せない）。**
+    #
+    # puma 8 は `--port` だけ渡すと **`[::]` に bind する**（7 までは `0.0.0.0`）。
+    # ⚠ FreeBSD は `net.inet6.ip6.v6only` の既定が 1 なので、⚠⚠ **IPv4 の接続を
+    # 一切受けなくなる。**nginx の `proxy_pass http://localhost:3009` が IPv4 に
+    # 落ちると、**アプリは生きているのに 502** になる（2026-08-13・dev25 で実際に踏んだ）。
+    # `pooza/chubo2#105`（proxy_pass の localhost が ::1 に落ちる）と同じ型の罠。
+    #
+    # ⚠ **IPv4 と IPv6 を両方 bind する手は採れない。**Linux は `[::]` が IPv4 を
+    # 兼ねるため、2 つ並べると 2 本目が `EADDRINUSE` で落ちる（実測）。
+    # **逆プロキシからしか叩かれない**ので、puma 7 と同じ `0.0.0.0` に揃える。
     def command
       return Ginseng::CommandLine.new([
         'bundle', 'exec', 'puma',
         File.join(Environment.dir, 'config.ru'),
-        '--port', config['/puma/port'].to_s,
+        '--bind', "tcp://0.0.0.0:#{config['/puma/port']}",
         '--environment', Environment.type
       ])
     end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -6,7 +6,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/cure-api
-  version: 3.1.2
+  version: 3.1.3
 gas:
   girls:
     url: https://script.google.com/macros/s/AKfycbyz2apomjlyawkhLI-XvZveeEPVvLXmGzshHiE9mfsZT8DOOKAwKRQ_CxzfBiv7Qki33A/exec


### PR DESCRIPTION
## ⚠⚠ puma 8 が IPv6 のみで待ち受けて 502 になる

3.1.2 を dev25 に入れたら、**localhost:3009 は 200 なのに `https://cure-api.st2.precure.ml` が 502** だった。

```
proxy_pass http://localhost:3009;   ← nginx

127.0.0.1  HTTP 000   ← 繋がらない
[::1]      HTTP 200   ← IPv6 だけ生きている
```

**puma 8 は `--port` だけ渡すと `[::]` に bind する**（7 までは `0.0.0.0`）。⚠ FreeBSD は `net.inet6.ip6.v6only` の既定が 1 なので、⚠⚠ **IPv4 の接続を一切受けない。**

⚠ **アプリは生きているのに 502** という形なので、プロセス監視では検知できない。`pooza/chubo2#105`（proxy_pass の localhost が ::1 に落ちる）と同じ型の罠。

### ⚠ 両方 bind する手は採れない

Linux は `[::]` が IPv4 を兼ねるため、`0.0.0.0` と `[::]` を並べると **2 本目が `EADDRINUSE` で落ちる**（実測）。⚠ **逆プロキシからしか叩かれない**ので、puma 7 と同じ `0.0.0.0` に揃える。

## docs

⚠ ステージングのドメインが `cure-api.st.precure.ml` と書かれていたが**名前解決できない**。正しくは `cure-api.st2.precure.ml`。

## 確認

ローカルで常駐させて IPv4 経由の疎通まで見た。

```
PumaDaemon is running (PID ...)
127.0.0.1  HTTP 200
localhost  HTTP 200
```

`rubocop` 無指摘 / `rake test` 27 tests 0 failures。